### PR TITLE
Fix npm start for server

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ Registers the Tigris data models with Tigris. For more info, see the
 
 
 #### `npm run build -w=@tern-app/shared`  
-Builds the shared package to make them accessible to node
+Builds the shared package for both ESM and CJS targets.
 
 #### `npm run start -w=@tern-app/server`
 

--- a/README.md
+++ b/README.md
@@ -153,6 +153,10 @@ The application will reload if you make edits.
 Registers the Tigris data models with Tigris. For more info, see the
 [Tigris data modeling with TypeScript docs](https://www.tigrisdata.com/docs/sdkstools/typescript/database/datamodel/?utm_source=github&utm_medium=github&utm_campaign=tern-stack-template).
 
+
+#### `npm run build -w=@tern-app/shared`  
+Builds the shared package to make them accessible to node
+
 #### `npm run start -w=@tern-app/server`
 
 Runs the built output from `dist`.

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "clean": "rimraf ./dist",
     "prebuild": "npm run clean && npm install",
-    "build": "npx tsc",
+    "build": "npx tsc --build",
     "postbuild": "npm run setup",
     "setup": "npx ts-node ./scripts/setup.ts",
     "prestart": "npm run build",

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -10,7 +10,7 @@
     "postbuild": "npm run setup",
     "setup": "npx ts-node ./scripts/setup.ts",
     "prestart": "npm run build",
-    "start": "node dist/src/index.js",
+    "start": "node --conditions=production dist/src/index.js",
     "predev": "npm run setup",
     "dev": "npx nodemon"
   },

--- a/apps/server/tsconfig.json
+++ b/apps/server/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "./dist"
+    "outDir": "./dist",
+    "module": "commonjs"
   }
 }

--- a/apps/server/tsconfig.json
+++ b/apps/server/tsconfig.json
@@ -4,5 +4,9 @@
     "outDir": "./dist",
     "module": "commonjs"
   },
-  "references": [{ "path": "../../packages/shared" }]
+  "references": [
+    {
+      "path": "../../packages/shared/tsconfig.json"
+    }
+  ]
 }

--- a/apps/server/tsconfig.json
+++ b/apps/server/tsconfig.json
@@ -3,5 +3,6 @@
   "compilerOptions": {
     "outDir": "./dist",
     "module": "commonjs"
-  }
+  },
+  "references": [{ "path": "../../packages/shared" }]
 }

--- a/packages/shared/.gitignore
+++ b/packages/shared/.gitignore
@@ -1,0 +1,5 @@
+# testing
+/coverage
+
+# production
+/dist

--- a/packages/shared/.gitignore
+++ b/packages/shared/.gitignore
@@ -3,3 +3,6 @@
 
 # production
 /dist
+
+# build logs
+tsconfig.tsbuildinfo

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -2,9 +2,10 @@
   "name": "@tern-app/shared",
   "version": "0.1.0",
   "description": "",
-  "main": "src/index.ts",
+  "main": "dist/index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "build": "npx tsc"
   },
   "keywords": [],
   "author": "",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -2,10 +2,18 @@
   "name": "@tern-app/shared",
   "version": "0.1.0",
   "description": "",
-  "main": "dist/index.js",
+  "exports": {
+    "import": "./dist/mjs/index.js",
+    "require": "./dist/cjs/index.js"
+  },
+  "files": [
+		"dist/**/*"
+	],
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "npx tsc"
+    "build": "npm run build-cjs && npm run build-mjs",
+    "build-cjs": "tsc -p tsconfig.json",
+    "build-mjs": "tsc -p tsconfig-mjs.json"
   },
   "keywords": [],
   "author": "",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -3,6 +3,10 @@
   "version": "0.1.0",
   "description": "",
   "main": "src/index.ts",
+  "exports": {
+    "import": "./dist/mjs/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "files": [
 		"dist/**/*"
 	],

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -4,7 +4,10 @@
   "description": "",
   "main": "src/index.ts",
   "exports": {
-    "require": "./dist/cjs/index.js",
+    "production": {
+      "require": "./dist/cjs/index.js",
+      "default": "./src/index.ts"
+    },
     "default": "./src/index.ts"
   },
   "files": [

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -2,10 +2,7 @@
   "name": "@tern-app/shared",
   "version": "0.1.0",
   "description": "",
-  "exports": {
-    "import": "./dist/mjs/index.js",
-    "require": "./dist/cjs/index.js"
-  },
+  "main": "src/index.ts",
   "files": [
 		"dist/**/*"
 	],

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -4,8 +4,8 @@
   "description": "",
   "main": "src/index.ts",
   "exports": {
-    "import": "./dist/mjs/index.js",
-    "require": "./dist/cjs/index.js"
+    "require": "./dist/cjs/index.js",
+    "default": "./src/index.ts"
   },
   "files": [
 		"dist/**/*"

--- a/packages/shared/tsconfig-mjs.json
+++ b/packages/shared/tsconfig-mjs.json
@@ -1,0 +1,7 @@
+{
+    "extends": "../../tsconfig.base.json",
+    "compilerOptions": {
+      "rootDir": "src",
+      "outDir": "dist/mjs"
+    }
+  }

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "dist/cjs",
-    "module": "commonjs"
+    "module": "commonjs",
+    "composite": true
   }
 }

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "rootDir": "src",
     "outDir": "./dist",
     "module": "commonjs"
   }

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -1,3 +1,7 @@
 {
-  "extends": "../../tsconfig.base.json"
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "module": "commonjs"
+  }
 }

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "./dist",
+    "outDir": "dist/cjs",
     "module": "commonjs"
   }
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -8,6 +8,8 @@
     "skipLibCheck": true,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
+    "declaration": true,
+    "sourceMap": true,
     "outDir": "./dist"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "files": [],
   "references": [
-    { "path": "packages/tigris" },
+    { "path": "packages/shared" },
     { "path": "apps/client" },
     { "path": "apps/server" }
   ]


### PR DESCRIPTION
Modify workspace configuration to make the above command work.

```sh
npm run start -w=@tern-app/server
```

### Background
The above command was failing because our server "code" used commonjs instead of module.
So we needed to 'build' to target commonjs. That fixed the start command for the server but broke the 
build command for the client application.

### Hybrid builds for cjs and mjs
I ended up building our shared package for both esm and commonjs targets.
And used the conditional exports to match the appropriate entry point for the calling code.

fixes /#1
/claim #1